### PR TITLE
Fix faulty stage direction encoding

### DIFF
--- a/xml/A04539.xml
+++ b/xml/A04539.xml
@@ -758,11 +758,12 @@
       <w lemma="devil" pos="n1" reg="Devil" xml:id="A04539-002-b-0700">Diuill</w>
       <pc unit="sentence" xml:id="A04539-002-b-0710">.</pc>
      </l>
-     <stage xml:id="A04539-e100220">
+     <sp>
+     <speaker xml:id="A04539-e100220">
       <w lemma="Francis" pos="nn1" xml:id="A04539-002-b-0720">Francis</w>
       <w lemma="Guicchiardine" pos="nn1" xml:id="A04539-002-b-0730">Guicchiardine</w>
       <pc unit="sentence" xml:id="A04539-002-b-0740">.</pc>
-     </stage>
+     </speaker>
      <l xml:id="A04539-e100230">
       <w lemma="send" pos="vvn" xml:id="A04539-002-b-0750">SEnt</w>
       <w lemma="from" pos="acp" xml:id="A04539-002-b-0760">from</w>
@@ -910,6 +911,7 @@
       <w lemma="declare" pos="vvz" xml:id="A04539-002-b-1900">declares</w>
       <pc unit="sentence" xml:id="A04539-002-b-1910">.</pc>
      </l>
+    </sp>
      <stage xml:id="A04539-e100380">
       <w lemma="he" pos="pns" reg="He" xml:id="A04539-002-b-1920">Hee</w>
       <w lemma="with" pos="acp" xml:id="A04539-002-b-1930">with</w>
@@ -926,8 +928,6 @@
      <stage xml:id="A04539-e100390">
       <w lemma="enter" pos="vvb" xml:id="A04539-002-b-2030">Enter</w>
       <pc xml:id="A04539-002-b-2040">,</pc>
-     </stage>
-     <p xml:id="A04539-e100400">
       <w lemma="at" pos="acp" xml:id="A04539-002-b-2050">At</w>
       <w lemma="one" pos="crd" xml:id="A04539-002-b-2060">one</w>
       <w lemma="door" pos="n1" reg="door" xml:id="A04539-002-b-2070">doore</w>
@@ -999,12 +999,14 @@
       <w lemma="of" pos="acp" xml:id="A04539-002-b-2720">of</w>
       <w lemma="hand" pos="n2" xml:id="A04539-002-b-2730">hands</w>
       <pc unit="sentence" xml:id="A04539-002-b-2740">.</pc>
+      </stage>
       <stage xml:id="A04539-e100410">
        <w lemma="n/a" pos="fla" rend="hi" xml:id="A04539-002-b-2750">Exeunt</w>
        <w lemma="Card." pos="ab" xml:id="A04539-002-b-2760">Card.</w>
        <w lemma="n/a" pos="fla" rend="hi" xml:id="A04539-002-b-2770">Manet</w>
        <w lemma="Roderigo" pos="nn1" xml:id="A04539-002-b-2780">Roderigo</w>
       </stage>
+      <stage>
       <pb facs="tcp:23109:3" xml:id="A04539-003-a"/>
       <w lemma="To" pos="prt" xml:id="A04539-003-a-0010">To</w>
       <w lemma="who" pos="crq" reg="whom" type="unclear" xml:id="A04539-003-a-0020">whome</w>
@@ -1292,7 +1294,7 @@
       <w lemma="and" pos="cc" xml:id="A04539-003-a-2830">and</w>
       <w lemma="depart" pos="vvz" xml:id="A04539-003-a-2840">departeth</w>
       <pc unit="sentence" xml:id="A04539-003-a-2850">.</pc>
-     </p>
+     </stage>
      <stage xml:id="A04539-e100420">
       <w lemma="Guicchiardine" pos="nn1" xml:id="A04539-003-a-2860">Guicchiardine</w>
       <pc unit="sentence" xml:id="A04539-003-a-2870">.</pc>

--- a/xml/A17460.xml
+++ b/xml/A17460.xml
@@ -1199,7 +1199,7 @@
        <w lemma="this" pos="d" xml:id="A17460-004-a-1280">this</w>
        <pc unit="sentence" xml:id="A17460-004-a-1290">?</pc>
       </l>
-      <stage xml:id="A17460-e100890">
+      <p xml:id="A17460-e100890">
        <w lemma="Amaymon" pos="nn1" rend="hi" xml:id="A17460-004-a-1300">Amaymon</w>
        <w lemma="king" pos="n1" xml:id="A17460-004-a-1310">King</w>
        <w lemma="of" pos="acp" xml:id="A17460-004-a-1320">of</w>
@@ -1247,7 +1247,7 @@
        <w lemma="till" pos="acp" xml:id="A17460-004-a-1740">till</w>
        <w lemma="noon" pos="n1" reg="Noon" xml:id="A17460-004-a-1750">Noone</w>
        <pc unit="sentence" xml:id="A17460-004-a-1760">.</pc>
-      </stage>
+      </p>
       <l xml:id="A17460-e100900">
        <w lemma="pish" pos="uh" xml:id="A17460-004-a-1770">Pish</w>
        <pc xml:id="A17460-004-a-1780">,</pc>
@@ -1258,7 +1258,7 @@
        <w lemma="i" pos="pno" xml:id="A17460-004-a-1830">me</w>
        <pc unit="sentence" xml:id="A17460-004-a-1840">.</pc>
       </l>
-      <stage xml:id="A17460-e100910">
+      <p xml:id="A17460-e100910">
        <w lemma="Asmody" pos="nn1" rend="hi" xml:id="A17460-004-a-1850">Asmody</w>
        <pc rend="hi" xml:id="A17460-004-a-1860">;</pc>
        <w lemma="a" pos="d" xml:id="A17460-004-a-1870">a</w>
@@ -1368,14 +1368,14 @@
        <w lemma="man" pos="n1" xml:id="A17460-004-a-2910">man</w>
        <w lemma="invisible" pos="j" reg="invisible" xml:id="A17460-004-a-2920">inuisible</w>
        <pc unit="sentence" xml:id="A17460-004-a-2930">.</pc>
-      </stage>
+      </p>
       <l xml:id="A17460-e100920">
        <w lemma="ay" pos="uh" reg="ay" xml:id="A17460-004-a-2940">I</w>
        <pc xml:id="A17460-004-a-2950">,</pc>
        <w lemma="this" pos="d" xml:id="A17460-004-a-2960">this</w>
        <pc unit="sentence" xml:id="A17460-004-a-2970">.</pc>
       </l>
-      <stage xml:id="A17460-e100930">
+      <p xml:id="A17460-e100930">
        <pb facs="tcp:7776:4" xml:id="A17460-004-b"/>
        <w lemma="he" pos="pns" xml:id="A17460-004-b-0010">He</w>
        <w lemma="show" pos="vvz" reg="showeth" xml:id="A17460-004-b-0020">sheweth</w>
@@ -1385,7 +1385,7 @@
        <w lemma="treasure" pos="n1" xml:id="A17460-004-b-0060">Treasure</w>
        <w lemma="lie" pos="vvi" reg="lie" xml:id="A17460-004-b-0070">lye</w>
        <pc unit="sentence" xml:id="A17460-004-b-0080">.</pc>
-      </stage>
+      </p>
       <l xml:id="A17460-e100940">
        <w lemma="I" pos="pns" xml:id="A17460-004-b-0090">I</w>
        <w lemma="do" pos="vvbx" reg="do not" xml:id="A17460-004-b-0100">donnot</w>
@@ -1394,14 +1394,14 @@
        <w lemma="treasure" pos="n1" xml:id="A17460-004-b-0130">Treasure</w>
        <pc unit="sentence" xml:id="A17460-004-b-0140">.</pc>
       </l>
-      <stage xml:id="A17460-e100950">
+      <p xml:id="A17460-e100950">
        <w lemma="he" pos="pns" xml:id="A17460-004-b-0150">He</w>
        <w lemma="make" pos="vvz" xml:id="A17460-004-b-0160">maketh</w>
        <w lemma="a" pos="d" xml:id="A17460-004-b-0170">a</w>
        <w lemma="man" pos="n1" xml:id="A17460-004-b-0180">man</w>
        <w lemma="invisible" pos="j" reg="invisible" xml:id="A17460-004-b-0190">inuisible</w>
        <pc unit="sentence" xml:id="A17460-004-b-0200">.</pc>
-      </stage>
+      </p>
       <l xml:id="A17460-e100960">
        <w lemma="This" pos="d" xml:id="A17460-004-b-0210">This</w>
        <pc xml:id="A17460-004-b-0220">,</pc>
@@ -1507,7 +1507,7 @@
        <w lemma="name" pos="n2" xml:id="A17460-004-b-1140">Names</w>
        <pc xml:id="A17460-004-b-1150">:</pc>
       </l>
-      <stage xml:id="A17460-e101010">
+      <p xml:id="A17460-e101010">
        <w lemma="Panthon" pos="nn1" xml:id="A17460-004-b-1160">Panthon</w>
        <pc xml:id="A17460-004-b-1170">,</pc>
        <w lemma="Adonay" pos="nn1" xml:id="A17460-004-b-1180">Adonay</w>
@@ -1582,7 +1582,7 @@
        <w lemma="the" pos="d" rend="hi" xml:id="A17460-004-b-1870">the</w>
        <w lemma="north" pos="n1" rend="hi" xml:id="A17460-004-b-1880">North</w>
        <pc rend="hi" unit="sentence" xml:id="A17460-004-b-1890">.</pc>
-      </stage>
+      </p>
       <stage xml:id="A17460-e101020">
        <w lemma="enter" pos="vvb" xml:id="A17460-004-b-1900">Enter</w>
        <w lemma="landoffe" pos="nn1" rend="hi" xml:id="A17460-004-b-1910">Landoffe</w>

--- a/xml/A20062.xml
+++ b/xml/A20062.xml
@@ -10823,7 +10823,7 @@
      <pc rend="hi" xml:id="A20062-012-a-2120">,</pc>
      <w lemma="lookingglass" pos="n1" reg="looking-glass" rend="hi" xml:id="A20062-012-a-2130">looking-glasse</w>
      <w lemma="and" pos="cc" rend="hi" xml:id="A20062-012-a-2140">and</w>
-     <w lemma="chasing-dish" pos="n1" rend="hi" xml:id="A20062-012-a-2150">chasing-dish</w>
+     <w lemma="chafing-dish" pos="n1" rend="hi" xml:id="A20062-012-a-2150">chafing-dish</w>
      <pc rend="hi" xml:id="A20062-012-a-2160">,</pc>
      <w lemma="those" pos="d" rend="hi" xml:id="A20062-012-a-2170">Those</w>
      <w lemma="be" pos="vvg" rend="hi" xml:id="A20062-012-a-2180">being</w>


### PR DESCRIPTION
Encoded a dumb show as a stage direction, which was originally marked up as dialog. You might want to check this change properly. I was unable to clone the repo on my pc and the file is too big to edit it directly in git. I ended up just editing the file on my pc and uploading it directly to git. However, I cannot properly track the changes that way.