### PR TITLE
Fix misattributed dialog

### DIFF
--- a/xml/A07023.xml
+++ b/xml/A07023.xml
@@ -17235,6 +17235,8 @@
        <w lemma="kiss" pos="n1" reg="kiss" xml:id="A07023-021-b-0350">kisse</w>
        <pc unit="sentence" xml:id="A07023-021-b-0360">.</pc>
       </l>
+     </sp>
+     <sp who="A07023-lord">
       <stage xml:id="A07023-e116720">
        <w lemma="enter" pos="vvb" xml:id="A07023-021-b-0370">Enter</w>
        <w lemma="a" pos="d" xml:id="A07023-021-b-0380">a</w>


### PR DESCRIPTION
I never know how this has to be weaved into your workflow, but there is a misattributed speech here. The character of "A07023-lord" does not appear anywhere else in the play, so you can still change the ID, if you want to.